### PR TITLE
Fixes PLIN-2090 Deploy Retrieve Site Metadata

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -187,7 +187,7 @@ func executePlanItem(api *platform.RestApi, plan types.Plan) (*io.ReadCloser, er
 	}
 
 	if verbose {
-		fmt.Println(text.SuccessWithTime("Success Retrieving from Source", deployStart))
+		fmt.Println(text.SuccessWithTime("Success Deploying to Source", deployStart))
 	}
 	defer (*planResult).Close()
 	return planResult, nil

--- a/cmd/retrieve.go
+++ b/cmd/retrieve.go
@@ -183,12 +183,12 @@ func readFileFromZipAndWriteToFilesystem(file *zip.File, targetLocation string, 
 	}
 
 	// If this file name contains a /, make sure that we create the
-	if pathParts := strings.Split(file.Name, "/"); len(pathParts) > 0 {
+	if pathParts := strings.Split(file.Name, string(filepath.Separator)); len(pathParts) > 0 {
 		// Remove the actual file name from the slice,
 		// i.e. pages/MyAwesomePage.xml ---> pages
 		pathParts = pathParts[:len(pathParts)-1]
 		// and then make dirs for all paths up to that point, i.e. pages, apps
-		intermediatePath := filepath.Join(targetLocation, strings.Join(pathParts[:], ","))
+		intermediatePath := filepath.Join(targetLocation, strings.Join(pathParts[:], string(filepath.Separator)))
 		//if the desired directory isn't there, create it
 		if _, err := os.Stat(intermediatePath); err != nil {
 			if verbose {

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -137,7 +137,7 @@ func (conn *RestConnection) Refresh() error {
 	result := OAuthResponse{}
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return err
+		return httperror.New(resp.Status, resp.Body)
 	}
 
 	conn.AccessToken = result.AccessToken


### PR DESCRIPTION
Adds ability to deploy/retrieve site configuration and custom logos.

1. Correct handling of subfolders in metadata.
2. Add the "site" folder to the list of folders that are accepted by the CLI.