### PR TITLE
Fixes PLIN-2280 Support for auth provider deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ IMAGE ?= golang
 ARCH=amd64
 OS=darwin
 
-VERSION=0.4.1
+VERSION=0.4.2
 
 .PHONY: setup fmt vendored
 

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -43,7 +43,7 @@ type RestApi struct {
 	Connection *RestConnection
 }
 
-var VERSION string = "0.4.1"
+var VERSION string = "0.4.2"
 
 // Login logs a given user into a target Skuid Platform site and returns a RestApi connection
 // that can be used to make HTTP requests
@@ -121,7 +121,7 @@ func (conn *RestConnection) Refresh() error {
 	}
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("User-Agent", "Skuid-CLI/" + VERSION)
+	req.Header.Add("User-Agent", "Skuid-CLI/"+VERSION)
 
 	resp, err := getClientForProxyURL(conn.MetadataServiceProxy).Do(req)
 
@@ -184,11 +184,11 @@ func (conn *RestConnection) MakeRequest(method string, url string, payload io.Re
 		return nil, err
 	}
 
-	req.Header.Add("Authorization", "Bearer " + conn.AccessToken)
+	req.Header.Add("Authorization", "Bearer "+conn.AccessToken)
 	if contentType != "" {
 		req.Header.Add("Content-Type", contentType)
 	}
-	req.Header.Add("User-Agent", "Skuid-CLI/" + VERSION)
+	req.Header.Add("User-Agent", "Skuid-CLI/"+VERSION)
 
 	resp, err := getClientForProxyURL(conn.MetadataServiceProxy).Do(req)
 
@@ -235,7 +235,7 @@ func (conn *RestConnection) MakeJWTRequest(method string, url string, payload io
 	if contentType != "" {
 		req.Header.Add("Content-Type", contentType)
 	}
-	req.Header.Add("User-Agent", "Skuid-CLI/" + VERSION)
+	req.Header.Add("User-Agent", "Skuid-CLI/"+VERSION)
 
 	// Send the public key endpoint so that warden can configure a JWT key if needed
 	req.Header.Add("x-skuid-public-key-endpoint", conn.Host+"/api/v1/site/verificationkey")

--- a/types/plan.go
+++ b/types/plan.go
@@ -17,6 +17,7 @@ type Plan struct {
 
 type Metadata struct {
 	Apps           []string `json:"apps"`
+	AuthProviders  []string `json:"authproviders"`
 	ComponentPacks []string `json:"componentpacks"`
 	DataServices   []string `json:"dataservices"`
 	DataSources    []string `json:"datasources"`

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Name of this version of Skuid CLI
-const Name = "0.4.1"
+const Name = "0.4.2"


### PR DESCRIPTION
Looks like we forgot to add auth providers to the types struct. I think this has been broken for a long time.