### PR TITLE
PLIN-2358 version bump 0.4.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ IMAGE ?= golang
 ARCH=amd64
 OS=darwin
 
-VERSION=0.4.3
+VERSION=0.4.4
 
 .PHONY: setup fmt vendored
 

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -43,7 +43,7 @@ type RestApi struct {
 	Connection *RestConnection
 }
 
-var VERSION string = "0.4.3"
+var VERSION string = "0.4.4"
 
 // Login logs a given user into a target Skuid Platform site and returns a RestApi connection
 // that can be used to make HTTP requests

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Name of this version of Skuid CLI
-const Name = "0.4.3"
+const Name = "0.4.4"


### PR DESCRIPTION
Just bumping the version in a few places to match the release: https://github.com/skuid/skuid-cli/releases/tag/0.4.4. I hate when I forget to do this.