### PR TITLE
Fix assertions for retrieve test for non-deterministic slice element ordering

### DIFF
--- a/cmd/retrieve_test.go
+++ b/cmd/retrieve_test.go
@@ -216,8 +216,8 @@ func TestRetrieve(t *testing.T) {
 			for _, file := range filesMap {
 				filesCreated = append(filesCreated, file)
 			}
-			assert.Equal(t, tc.wantFiles, filesCreated)
-			assert.Equal(t, tc.wantDirectories, directoriesCreated)
+			assert.ElementsMatch(t, tc.wantFiles, filesCreated)
+			assert.ElementsMatch(t, tc.wantDirectories, directoriesCreated)
 			if tc.wantError != nil {
 				assert.Equal(t, tc.wantError, err)
 			} else {


### PR DESCRIPTION
We should be using `assert.ElementsMatch` in places where ordering doesn't matter for slice elements.
https://godoc.org/github.com/stretchr/testify/assert#ElementsMatch