### PR TITLE
PLIN-2705 Support new app name flag posted to pliny retrieve plan endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GO_PKGS = $$(go list ./... | grep -v vendor)
 REPOSITORY = 095427547185.dkr.ecr.us-west-2.amazonaws.com/skuid/skuid
 TAG = latest
 VOL_PATH=/go/src/github.com/skuid/skuid
-GO_VERSION=1.14
+GO_VERSION=1.15
 IMAGE ?= golang
 
 ARCH=amd64

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ var (
 	appClientSecret      string
 	apiVersion           string
 	host                 string
+	appName              string
 	module               string
 	page                 string
 	password             string
@@ -64,6 +65,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&variablevalue, "value", "", "The value for the variable to be set")
 	RootCmd.PersistentFlags().StringVar(&variabledataservice, "dataservice", "", "Optional, the name of a private data service in which the variable should be created. Leave blank to store in the default data service.")
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Display all possible logging info")
+	RootCmd.PersistentFlags().StringVarP(&appName, "app", "a", "", "Filter retrieve/deploy to a specific Skuid App")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/types/plan.go
+++ b/types/plan.go
@@ -31,6 +31,10 @@ type Metadata struct {
 	Themes         []string `json:"themes"`
 }
 
+type RetrieveFilter struct {
+	AppName string `json:"appName"`
+}
+
 // GetMetadataTypeDirNames returns the directory names for a type
 func GetMetadataTypeDirNames() []string {
 	metadataType := reflect.TypeOf(Metadata{})


### PR DESCRIPTION
Note: if you actually *use* the new `--app <name>` flag, pliny is going to complain at you.