### PR TITLE
PLIN-3890-component-pack-issue-while-retrieve-and-deploy-with-cli-cli-fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ skuid_darwin_amd64
 skuid_linux_amd64
 skuid_windows_amd64.exe
 .idea
+*.log

--- a/cmd/retrieve.go
+++ b/cmd/retrieve.go
@@ -117,8 +117,8 @@ func writeResultsToDisk(results []*io.ReadCloser, fileCreator FileCreator, direc
 
 		tmpFileName, err := createTemporaryFile(result)
 		if err != nil {
-				return err
-			}
+			return err
+		}
 		// schedule cleanup of temp file
 		defer os.Remove(tmpFileName)
 
@@ -133,8 +133,8 @@ func writeResultsToDisk(results []*io.ReadCloser, fileCreator FileCreator, direc
 		// unzip the contents of our temp zip file
 		err = unzip(tmpFileName, targetDir, pathMap, fileCreator, directoryCreator, existingFileReader)
 		if err != nil {
-				return err
-			}
+			return err
+		}
 	}
 
 	fmt.Printf("Results written to %s\n", targetDirFriendly)
@@ -423,7 +423,7 @@ func executeRetrievePlan(api *platform.RestApi, plans map[string]types.Plan) ([]
 	for _, plan := range plans {
 		metadataBytes, err := json.Marshal(types.RetrieveRequest{
 			Metadata: plan.Metadata,
-			DoZip: !nozip,
+			DoZip:    !nozip,
 		})
 		if err != nil {
 			return nil, err

--- a/types/plan.go
+++ b/types/plan.go
@@ -113,7 +113,7 @@ func (m Metadata) FilterMetadataItem(relativeFilePath string) bool {
 	// Check for children of a component pack
 	if metadataType == "componentpacks" {
 		filePathParts := strings.Split(filePath, string(filepath.Separator))
-		if len(filePathParts) == 2 && StringSliceContainsKey(validMetadataNames, filePathParts[0]) {
+		if len(filePathParts) >= 2 && StringSliceContainsKey(validMetadataNames, filePathParts[0]) {
 			return true
 		}
 	}

--- a/ziputils/ziputils.go
+++ b/ziputils/ziputils.go
@@ -63,7 +63,7 @@ func Archive(inFilePath string, writer io.Writer, metadataFilter *types.Metadata
 				return false
 			}
 		}
-		return true 
+		return true
 	})
 }
 


### PR DESCRIPTION
# Jira Issue URL

https://skuidify.atlassian.net/browse/PLIN-3890

# High-Level Description

- Fix the issue with subdirectories of a component pack

# Changelog:

- Added a condition that let uploads subdirectories of a component pack
- Fix some code structure done by vscode after save automatically
- Ignore *.log files for git
