### PR TITLE
PLIN-4162-ds-os-with-a-field-named-name-get-duplicated-in-cli-retrieval-of-datasource-object-permissions

### DIFF
--- a/pkg/util/sort.go
+++ b/pkg/util/sort.go
@@ -23,7 +23,8 @@ func InsertNamePlaceholders(in map[string]interface{}) map[string]interface{} {
 	for k, v := range in {
 		if k == "name" {
 			delete(in, k)
-			in[fmt.Sprintf("%v", PLACEHOLDER)] = v
+			k = fmt.Sprintf("%v", PLACEHOLDER)
+			in[k] = v
 		}
 		if m, anotherMap := v.(map[string]interface{}); anotherMap {
 			in[k] = InsertNamePlaceholders(m)

--- a/pkg/util/sort_test.go
+++ b/pkg/util/sort_test.go
@@ -53,6 +53,40 @@ var (
 		"d": "d",
 		"x":"x"
 	}`
+
+	sortedNestedNameObject = `{
+		"name": {
+			"createable": false,
+			"queryable": false,
+			"updateable": false
+		},
+		"a": "a",
+		"c": "c",
+		"d": "d",
+		"nested": {
+			"name":"name",
+			"a":"a"
+		},
+		"x":"x",
+		"z": "z"
+	}`
+
+	unsortedNestedNameObject = `{
+		"a": "a",
+		"z": "z",
+		"c": "c",
+		"name": {
+			"createable": false,
+			"queryable": false,
+			"updateable": false
+		},
+		"nested": {
+			"a":"a",
+			"name":"name"
+		},
+		"d": "d",
+		"x":"x"
+	}`
 )
 
 func TestSortJson(t *testing.T) {
@@ -80,6 +114,16 @@ func TestSortJson(t *testing.T) {
 			description: "unsorted nested",
 			given:       unsortedNested,
 			expected:    sortedNested,
+		},
+		{
+			description: "sorted nested name object",
+			given:       sortedNestedNameObject,
+			expected:    sortedNestedNameObject,
+		},
+		{
+			description: "unsorted nested name object",
+			given:       unsortedNestedNameObject,
+			expected:    sortedNestedNameObject,
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {


### PR DESCRIPTION
# Jira Issue URL

https://inflight.atlassian.net/browse/PLIN-4162

# High-Level Description

**name** key sometimes could be an object, so that made skuid-cli duplicate the key

# Changelog:

- name key as object fixed
