### PR TITLE
fix: resolve several issues with watch command

### DIFF
--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -92,15 +92,14 @@ func Watch(cmd *cobra.Command, _ []string) (err error) {
 				if relativeFilePath, err = filepath.Rel(targetDir, event.Path); err != nil {
 					return
 				}
-				metadataType := filepath.Dir(relativeFilePath)
-				fileName := filepath.Base(relativeFilePath)
+				metadataType, relativeEntityPath := pkg.GetEntityDetails(relativeFilePath)
 				var changedEntity string
 				if metadataType == "componentpacks" {
-					changedEntity = relativeFilePath
+					changedEntity = filepath.Join(metadataType, relativeEntityPath)
 				} else if metadataType == "site" {
 					changedEntity = "site"
 				} else {
-					changedEntity = filepath.Join(metadataType, strings.Split(fileName, ".")[0])
+					changedEntity = filepath.Join(metadataType, strings.Split(relativeEntityPath, ".")[0])
 				}
 				logging.WithFields(fields).Debug("Detected change to metadata type: " + changedEntity)
 				go func() {

--- a/pkg/metadata.go
+++ b/pkg/metadata.go
@@ -67,14 +67,7 @@ func (from NlxMetadata) GetFieldValueByName(target string) (names []string, err 
 // FilterItem returns true if the path meets the filter criteria, otherwise it returns false
 func (from NlxMetadata) FilterItem(item string) (keep bool) {
 	cleanRelativeFilePath := util.FromWindowsPath(item)
-	directory := filepath.Dir(cleanRelativeFilePath)
-	baseName := filepath.Base(cleanRelativeFilePath)
-
-	// Find the lowest level folder
-	dirSplit := strings.Split(directory, string(filepath.Separator))
-	metadataType, subFolders := dirSplit[0], dirSplit[1:]
-	filePathArray := append(subFolders, baseName)
-	filePath := strings.Join(filePathArray, string(filepath.Separator))
+	metadataType, filePath := GetEntityDetails(cleanRelativeFilePath)
 
 	validMetadataNames, err := from.GetFieldValueByName(metadataType)
 	if len(validMetadataNames) == 0 {
@@ -133,4 +126,17 @@ func GetMetadataTypeDirNames() (types []string) {
 	}
 
 	return types
+}
+
+// returns the metadatatype and filepath relative to metadata directory
+func GetEntityDetails(entityPath string) (metadataType string, relativeEntityPath string) {
+	directory := filepath.Dir(entityPath)
+	baseName := filepath.Base(entityPath)
+
+	// Find the lowest level folder
+	dirSplit := strings.Split(directory, string(filepath.Separator))
+	metadataType, subFolders := dirSplit[0], dirSplit[1:]
+	filePathArray := append(subFolders, baseName)
+	relativeEntityPath = strings.Join(filePathArray, string(filepath.Separator))
+	return
 }


### PR DESCRIPTION
# Jira Issue URL
N/A

# High-Level Description
Addresses several issues with the watch command as described in the issues mentioned below in Changelog section.

1. I was unable to find any mention in this repo and/or [Skuid CLI Docs](https://docs.skuid.com/latest/en/skuid/cli/) of the minimum required/supported version of Go.  The only reference to a version I could find was in the [CI workflow](https://github.com/skuid/skuid-cli/blob/master/.github/workflows/github-actions-release.yml#L24) which appears to use Go 1.20 so all testing was performed against this version.
2. I did not see any tests written for the `watch` command so all testing performed against `watch` was manual.  Testing was performed on Windows 11 & Ubuntu 20.04 (via WSL) but not on Mac as I don't have a Mac.  Without any tests, it's difficult to guarantee that no regressions have been introduced but manual testing of all the issues "passed" as did testing of random usage in/around the modified code.
3. Couldn't find any documentation on how to run the tests that do exist so utilized the [test command](https://github.com/skuid/skuid-cli/blob/master/.github/workflows/github-actions-release.yml#L33) in the CI workflow and the results were identical from before & after the changes.
4. This PR addresses one (#128) of the two issues (#138 being the other) related to unmodified files being deployed by watch when a file is changed.  Please see #138 for the remaining issue that exists that likely should be considered a **critical** issue and addressed ASAP.

# Changelog:
Resolves #127 - `watch` encounters `Unable to handle file change: stat : no such file or directory` exception if `-d` option is not specified
Resolves #128 - `watch` deploys all files in modified file directory that start with same character as modified file
Resolves #129 - `watch` command encounters `index out of range [1] with length 1` when `-d` option contains a `.`
Resolves #130 - `watch` command encounters `index out of range [2] with length 2` exception when `-d` directory name contains portion of its parent directory name
Resolves #131 - `watch` command encounters `index out of range [0] with length 0` exception
Resolves #132 - `watch` command encounters `index out of range [1] with length 1` when file outside of `-d` directory is modified
Addresses the watch portion of #136 - Logging field capturing the target directory is blank when executing `retrieve` or `watch` without `-d` option
